### PR TITLE
feat: :sparkles: add rebalance lifecycle events and coordinator ack tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ vendor/
 .DS_Store
 .cache
 playground/
+.trunk/
+.gocache/
+.cache/
+.gomodcache/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ It's good at distributed caching and publish/subscribe messaging.
 * Horizontally scalable,
 * Provides best-effort consistency guarantees without being a complete CP (indeed PA/EC) solution,
 * Distributes load fairly among cluster members with
-  a [consistent hash function](https://github.com/buraksezer/consistent),
+  a [consistent hash function](./internal/consistent),
 * Supports replication by default (with sync and async options),
 * Quorum-based voting for replica control,
 * Thread-safe by default,
@@ -140,6 +140,13 @@ Olric can send push cluster events to `cluster.events` channel. Available cluste
 * node-left-event
 * fragment-migration-event
 * fragment-received-even
+* rebalance-start-event
+* rebalance-complete-event
+
+Rebalance lifecycle events track routing table epochs. A rebalance starts when the coordinator publishes a new routing
+table (for example after a node join/leave), and completes only after all live members report that no further fragment
+moves are required for that routing table epoch. Use `rebalance-start-event` and `rebalance-complete-event` to track
+completion; `node-left-event` remains a membership signal, not a rebalance barrier.
 
 If you want to receive these events, set `true` to `EnableClusterEventsChannel` and subscribe to `cluster.events`
 channel.
@@ -239,7 +246,7 @@ partID = MOD(hash result, partition count)
 ```
 
 The partitions are being distributed among cluster members by using a consistent hashing algorithm. In order to get
-details, please see [buraksezer/consistent](https://github.com/buraksezer/consistent).
+details, please see [consistent](./internal/consistent).
 
 When a new cluster is created, one of the instances is elected as the **cluster coordinator**. It manages the partition
 table:

--- a/cluster_client_test.go
+++ b/cluster_client_test.go
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018-2024 Burak Sezer
  * Copyright 2025 Arsene Tochemey Gandote
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +18,7 @@ package olric
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -805,11 +805,45 @@ func TestClusterClient_smartPick(t *testing.T) {
 		require.NoError(t, c.Close(ctx))
 	}()
 
+	var expectedOwners map[string]struct{}
+	err = testutil.TryWithInterval(20, 100*time.Millisecond, func() error {
+		if err := c.fetchRoutingTable(); err != nil {
+			return err
+		}
+
+		raw := c.routingTable.Load()
+		if raw == nil {
+			return fmt.Errorf("routing table is empty")
+		}
+
+		routingTable, ok := raw.(RoutingTable)
+		if !ok {
+			return fmt.Errorf("routing table is corrupt")
+		}
+
+		owners := make(map[string]struct{})
+		for _, route := range routingTable {
+			if len(route.PrimaryOwners) == 0 {
+				continue
+			}
+			primary := route.PrimaryOwners[len(route.PrimaryOwners)-1]
+			owners[primary] = struct{}{}
+		}
+
+		if len(owners) == 0 {
+			return fmt.Errorf("routing table has no owners")
+		}
+		expectedOwners = owners
+		return nil
+	})
+	require.NoError(t, err)
+	expectedOwnerCount := len(expectedOwners)
+
 	clients := make(map[string]struct{})
 	for i := 0; i < 1000; i++ {
 		rc, err := c.smartPick("mydmap", testutil.ToKey(i))
 		require.NoError(t, err)
 		clients[rc.String()] = struct{}{}
 	}
-	require.Len(t, clients, 4)
+	require.Len(t, clients, expectedOwnerCount)
 }

--- a/events/cluster_events.go
+++ b/events/cluster_events.go
@@ -34,6 +34,8 @@ const (
 	KindNodeLeftEvent          = "node-left-event"
 	KindFragmentMigrationEvent = "fragment-migration-event"
 	KindFragmentReceivedEvent  = "fragment-received-event"
+	KindRebalanceStartEvent    = "rebalance-start-event"
+	KindRebalanceCompleteEvent = "rebalance-complete-event"
 )
 
 type Event interface {
@@ -206,6 +208,90 @@ func (f *FragmentReceivedEvent) Encode() (string, error) {
 			value = r.FieldByName(field).Int()
 		case "Source", "Kind", "DataStructure", "Identifier":
 			value = r.FieldByName(field).String()
+		default:
+			return nil, fmt.Errorf("invalid field: %s", field)
+		}
+		return value, nil
+	})
+}
+
+// RebalanceStartEvent marks the beginning of a rebalance epoch in the cluster.
+// It is emitted by the cluster coordinator after publishing a new routing table
+// and before data movement completes.
+//
+// Field usage:
+//   - Kind: event type identifier, always KindRebalanceStartEvent.
+//   - Source: coordinator address that emitted the event.
+//   - Epoch: routing table signature for this rebalance cycle. Correlate this
+//     with RebalanceCompleteEvent.Epoch to know when the cycle finishes.
+//   - Reason: why the rebalance started (e.g., "node-join", "node-left",
+//     "node-update", "periodic", "manual").
+//   - Node: the node associated with the trigger, if any (for example the
+//     joined or left node). May be empty for periodic/manual updates.
+//   - Timestamp: coordinator wall-clock time in nanoseconds since epoch.
+//
+// Application guidance: treat this as the start of data convergence for the
+// routing table epoch. Do not use node-left events as completion signals;
+// instead, wait for a matching RebalanceCompleteEvent with the same Epoch.
+type RebalanceStartEvent struct {
+	Kind      string `json:"kind"`
+	Source    string `json:"source"`
+	Epoch     uint64 `json:"epoch"`
+	Reason    string `json:"reason"`
+	Node      string `json:"node"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+func (r *RebalanceStartEvent) Encode() (string, error) {
+	fields := []string{"Timestamp", "Source", "Kind", "Epoch", "Reason", "Node"}
+	return encodeEvent(r, fields, func(rv reflect.Value, field string) (any, error) {
+		var value any
+		switch field {
+		case "Epoch":
+			value = rv.FieldByName(field).Uint()
+		case "Timestamp":
+			value = rv.FieldByName(field).Int()
+		case "Source", "Kind", "Reason", "Node":
+			value = rv.FieldByName(field).String()
+		default:
+			return nil, fmt.Errorf("invalid field: %s", field)
+		}
+		return value, nil
+	})
+}
+
+// RebalanceCompleteEvent marks the completion of a rebalance epoch.
+// It is emitted by the cluster coordinator after all live members have
+// acknowledged that no further fragment moves are required for the epoch.
+//
+// Field usage:
+//   - Kind: event type identifier, always KindRebalanceCompleteEvent.
+//   - Source: coordinator address that emitted the event.
+//   - Epoch: routing table signature for the completed rebalance cycle. Match
+//     against RebalanceStartEvent.Epoch.
+//   - Timestamp: coordinator wall-clock time in nanoseconds since epoch.
+//
+// Application guidance: treat this as the point when rebalancing is complete
+// for the given epoch. If a newer rebalance-start arrives before completion,
+// the previous epoch should be considered superseded.
+type RebalanceCompleteEvent struct {
+	Kind      string `json:"kind"`
+	Source    string `json:"source"`
+	Epoch     uint64 `json:"epoch"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+func (r *RebalanceCompleteEvent) Encode() (string, error) {
+	fields := []string{"Timestamp", "Source", "Kind", "Epoch"}
+	return encodeEvent(r, fields, func(rv reflect.Value, field string) (any, error) {
+		var value any
+		switch field {
+		case "Epoch":
+			value = rv.FieldByName(field).Uint()
+		case "Timestamp":
+			value = rv.FieldByName(field).Int()
+		case "Source", "Kind":
+			value = rv.FieldByName(field).String()
 		default:
 			return nil, fmt.Errorf("invalid field: %s", field)
 		}

--- a/events/cluster_events_test.go
+++ b/events/cluster_events_test.go
@@ -85,3 +85,33 @@ func TestClusterEvents_FragmentReceivedEvent(t *testing.T) {
 	expected := `{"timestamp":585199808000,"source":"127.0.0.1:3423","kind":"fragment-received-event","data_structure":"dmap","partition_id":123,"identifier":"mydmap","is_backup":false,"length":1234}`
 	require.Equal(t, expected, result)
 }
+
+func TestClusterEvents_RebalanceStartEvent(t *testing.T) {
+	var timestamp int64 = 585199808000 // Author's birthdate!
+	n := RebalanceStartEvent{
+		Kind:      KindRebalanceStartEvent,
+		Source:    "127.0.0.1:3423",
+		Epoch:     42,
+		Reason:    "node-left",
+		Node:      "127.0.0.1:3576",
+		Timestamp: timestamp,
+	}
+	result, err := n.Encode()
+	require.NoError(t, err)
+	expected := `{"timestamp":585199808000,"source":"127.0.0.1:3423","kind":"rebalance-start-event","epoch":42,"reason":"node-left","node":"127.0.0.1:3576"}`
+	require.Equal(t, expected, result)
+}
+
+func TestClusterEvents_RebalanceCompleteEvent(t *testing.T) {
+	var timestamp int64 = 585199808000 // Author's birthdate!
+	n := RebalanceCompleteEvent{
+		Kind:      KindRebalanceCompleteEvent,
+		Source:    "127.0.0.1:3423",
+		Epoch:     42,
+		Timestamp: timestamp,
+	}
+	result, err := n.Encode()
+	require.NoError(t, err)
+	expected := `{"timestamp":585199808000,"source":"127.0.0.1:3423","kind":"rebalance-complete-event","epoch":42}`
+	require.Equal(t, expected, result)
+}

--- a/internal/cluster/balancer/balancer.go
+++ b/internal/cluster/balancer/balancer.go
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018-2024 Burak Sezer
  * Copyright 2025 Arsene Tochemey Gandote
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +43,8 @@ type Balancer struct {
 	wg      sync.WaitGroup
 	ctx     context.Context
 	cancel  context.CancelFunc
+
+	lastAckedSignature uint64
 }
 
 func New(e *environment.Environment) *Balancer {
@@ -71,7 +72,11 @@ func (b *Balancer) isAlive() bool {
 	return true
 }
 
-func (b *Balancer) movePartition(sign uint64, part *partitions.Partition, owners ...discovery.Member) {
+func (b *Balancer) movePartition(sign uint64, part *partitions.Partition, owners ...discovery.Member) (bool, bool) {
+	var (
+		moved   bool
+		aborted bool
+	)
 	ownersStr := func() string {
 		var names []string
 		for _, owner := range owners {
@@ -90,6 +95,7 @@ func (b *Balancer) movePartition(sign uint64, part *partitions.Partition, owners
 		b.log.V(2).Printf("[INFO] Moving %s fragment: %s (kind: %s) on PartID: %d to %s",
 			f.Name(), name, part.Kind(), part.ID(), ownersStr)
 
+		moved = true
 		err := f.Move(part, name, owners)
 		if err != nil {
 			b.log.V(2).Printf("[ERROR] Failed to move %s fragment: %s on PartID: %d to %s: %v",
@@ -97,15 +103,20 @@ func (b *Balancer) movePartition(sign uint64, part *partitions.Partition, owners
 		}
 
 		// if this returns true, the iteration continues
-		return !b.breakLoop(sign)
+		if b.breakLoop(sign) {
+			aborted = true
+			return false
+		}
+		return true
 	})
+	return moved, aborted
 }
 
-func (b *Balancer) primaryCopies() {
-	sign := b.rt.Signature()
+func (b *Balancer) primaryCopies(sign uint64) (bool, bool) {
+	var moved bool
 	for partID := uint64(0); partID < b.config.PartitionCount; partID++ {
 		if b.breakLoop(sign) {
-			break
+			return moved, true
 		}
 
 		part := b.primary.PartitionByID(partID)
@@ -125,8 +136,13 @@ func (b *Balancer) primaryCopies() {
 		}
 
 		// This is a previous owner. Move the keys.
-		b.movePartition(sign, part, owner)
+		partitionMoved, aborted := b.movePartition(sign, part, owner)
+		moved = moved || partitionMoved
+		if aborted {
+			return moved, true
+		}
 	}
+	return moved, false
 }
 
 func (b *Balancer) breakLoop(sign uint64) bool {
@@ -143,12 +159,12 @@ func (b *Balancer) breakLoop(sign uint64) bool {
 	return false
 }
 
-func (b *Balancer) backupCopies() {
-	sign := b.rt.Signature()
+func (b *Balancer) backupCopies(sign uint64) (bool, bool) {
+	var moved bool
 LOOP:
 	for partID := uint64(0); partID < b.config.PartitionCount; partID++ {
 		if b.breakLoop(sign) {
-			break
+			return moved, true
 		}
 
 		part := b.backup.PartitionByID(partID)
@@ -184,8 +200,13 @@ LOOP:
 			continue LOOP
 		}
 
-		b.movePartition(sign, part, currentOwners...)
+		partitionMoved, aborted := b.movePartition(sign, part, currentOwners...)
+		moved = moved || partitionMoved
+		if aborted {
+			return moved, true
+		}
 	}
+	return moved, false
 }
 
 func (b *Balancer) triggerBalancer() {
@@ -197,13 +218,35 @@ func (b *Balancer) triggerBalancer() {
 		return
 	}
 
-	b.primaryCopies()
-
-	// TODO(arsene): using the default values will never perform a backup
-	// TODO(arsene): revisit this logic
-	if b.config.ReplicaCount > config.MinimumReplicaCount {
-		b.backupCopies()
+	sign := b.rt.Signature()
+	moved, aborted := b.primaryCopies(sign)
+	if aborted {
+		return
 	}
+
+	if b.config.ReplicaCount > config.MinimumReplicaCount {
+		backupMoved, aborted := b.backupCopies(sign)
+		moved = moved || backupMoved
+		if aborted {
+			return
+		}
+	}
+
+	if !moved {
+		b.tryAckRebalance(sign)
+	}
+}
+
+func (b *Balancer) tryAckRebalance(sign uint64) {
+	if sign == 0 || sign == b.lastAckedSignature {
+		return
+	}
+
+	if err := b.rt.SendRebalanceAck(sign); err != nil {
+		b.log.V(3).Printf("[WARN] Failed to send rebalance ack for signature %d: %v", sign, err)
+		return
+	}
+	b.lastAckedSignature = sign
 }
 
 func (b *Balancer) BalanceEagerly() {

--- a/internal/cluster/routingtable/discovery.go
+++ b/internal/cluster/routingtable/discovery.go
@@ -37,7 +37,11 @@ func (r *RoutingTable) bootstrapCoordinator() error {
 	defer r.Unlock()
 
 	r.fillRoutingTable()
-	_, err := r.updateRoutingTableOnCluster()
+	data, _, err := r.buildRoutingTablePayload()
+	if err != nil {
+		return err
+	}
+	_, err = r.updateRoutingTableOnCluster(data)
 	if err != nil {
 		return err
 	}

--- a/internal/cluster/routingtable/events.go
+++ b/internal/cluster/routingtable/events.go
@@ -65,3 +65,47 @@ func (r *RoutingTable) publishNodeLeftEvent(m *discovery.Member) {
 		r.log.V(3).Printf("[ERROR] Failed to publish NodeLeftEvent to %s: %v", events.ClusterEventsChannel, err)
 	}
 }
+
+func (r *RoutingTable) publishRebalanceStartEvent(epoch uint64, reason, node string) {
+	defer r.wg.Done()
+
+	rc := r.client.Get(r.this.String())
+	message := events.RebalanceStartEvent{
+		Kind:      events.KindRebalanceStartEvent,
+		Source:    r.this.String(),
+		Epoch:     epoch,
+		Reason:    reason,
+		Node:      node,
+		Timestamp: time.Now().UnixNano(),
+	}
+	data, err := message.Encode()
+	if err != nil {
+		r.log.V(3).Printf("[ERROR] Failed to encode RebalanceStartEvent: %v", err)
+		return
+	}
+	err = rc.Publish(r.ctx, events.ClusterEventsChannel, data).Err()
+	if err != nil {
+		r.log.V(3).Printf("[ERROR] Failed to publish RebalanceStartEvent to %s: %v", events.ClusterEventsChannel, err)
+	}
+}
+
+func (r *RoutingTable) publishRebalanceCompleteEvent(epoch uint64) {
+	defer r.wg.Done()
+
+	rc := r.client.Get(r.this.String())
+	message := events.RebalanceCompleteEvent{
+		Kind:      events.KindRebalanceCompleteEvent,
+		Source:    r.this.String(),
+		Epoch:     epoch,
+		Timestamp: time.Now().UnixNano(),
+	}
+	data, err := message.Encode()
+	if err != nil {
+		r.log.V(3).Printf("[ERROR] Failed to encode RebalanceCompleteEvent: %v", err)
+		return
+	}
+	err = rc.Publish(r.ctx, events.ClusterEventsChannel, data).Err()
+	if err != nil {
+		r.log.V(3).Printf("[ERROR] Failed to publish RebalanceCompleteEvent to %s: %v", events.ClusterEventsChannel, err)
+	}
+}

--- a/internal/cluster/routingtable/events_test.go
+++ b/internal/cluster/routingtable/events_test.go
@@ -96,3 +96,69 @@ func TestRoutingTable_publishNodeLeftEvent(t *testing.T) {
 	<-ctx.Done()
 	require.ErrorIs(t, context.Canceled, ctx.Err())
 }
+
+func TestRoutingTable_publishRebalanceStartEvent(t *testing.T) {
+	cluster := newTestCluster()
+	defer cluster.cancel()
+
+	c := testutil.NewConfig()
+	rt, err := cluster.addNode(c)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	rt.server.ServeMux().HandleFunc(protocol.PubSub.Publish, func(conn redcon.Conn, cmd redcon.Command) {
+		defer cancel()
+
+		publishCmd, err := protocol.ParsePublishCommand(cmd)
+		require.NoError(t, err)
+		require.Equal(t, events.ClusterEventsChannel, publishCmd.Channel)
+
+		v := events.RebalanceStartEvent{}
+		err = json.Unmarshal([]byte(publishCmd.Message), &v)
+		require.NoError(t, err)
+		require.Equal(t, events.KindRebalanceStartEvent, v.Kind)
+		require.Equal(t, rt.this.String(), v.Source)
+		require.Equal(t, uint64(42), v.Epoch)
+		require.Equal(t, "node-left", v.Reason)
+		require.Equal(t, "127.0.0.1:9999", v.Node)
+
+		conn.WriteInt(1)
+	})
+
+	rt.wg.Add(1)
+	go rt.publishRebalanceStartEvent(42, "node-left", "127.0.0.1:9999")
+	<-ctx.Done()
+	require.ErrorIs(t, context.Canceled, ctx.Err())
+}
+
+func TestRoutingTable_publishRebalanceCompleteEvent(t *testing.T) {
+	cluster := newTestCluster()
+	defer cluster.cancel()
+
+	c := testutil.NewConfig()
+	rt, err := cluster.addNode(c)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	rt.server.ServeMux().HandleFunc(protocol.PubSub.Publish, func(conn redcon.Conn, cmd redcon.Command) {
+		defer cancel()
+
+		publishCmd, err := protocol.ParsePublishCommand(cmd)
+		require.NoError(t, err)
+		require.Equal(t, events.ClusterEventsChannel, publishCmd.Channel)
+
+		v := events.RebalanceCompleteEvent{}
+		err = json.Unmarshal([]byte(publishCmd.Message), &v)
+		require.NoError(t, err)
+		require.Equal(t, events.KindRebalanceCompleteEvent, v.Kind)
+		require.Equal(t, rt.this.String(), v.Source)
+		require.Equal(t, uint64(42), v.Epoch)
+
+		conn.WriteInt(1)
+	})
+
+	rt.wg.Add(1)
+	go rt.publishRebalanceCompleteEvent(42)
+	<-ctx.Done()
+	require.ErrorIs(t, context.Canceled, ctx.Err())
+}

--- a/internal/cluster/routingtable/handlers.go
+++ b/internal/cluster/routingtable/handlers.go
@@ -23,5 +23,6 @@ import (
 
 func (r *RoutingTable) RegisterHandlers() {
 	r.server.ServeMux().HandleFunc(protocol.Internal.UpdateRouting, r.updateRoutingCommandHandler)
+	r.server.ServeMux().HandleFunc(protocol.Internal.RebalanceAck, r.rebalanceAckCommandHandler)
 	r.server.ServeMux().HandleFunc(protocol.Internal.LengthOfPart, r.lengthOfPartCommandHandler)
 }

--- a/internal/cluster/routingtable/operations.go
+++ b/internal/cluster/routingtable/operations.go
@@ -24,8 +24,9 @@ import (
 	"github.com/tidwall/redcon"
 	"github.com/vmihailenco/msgpack/v5"
 
-	"github.com/tochemey/olric/internal/cluster/partitions"
 	"github.com/tochemey/olric/internal/protocol"
+
+	"github.com/tochemey/olric/internal/cluster/partitions"
 )
 
 func (r *RoutingTable) lengthOfPartCommandHandler(conn redcon.Conn, cmd redcon.Command) {
@@ -130,4 +131,26 @@ func (r *RoutingTable) updateRoutingCommandHandler(conn redcon.Conn, cmd redcon.
 	r.wg.Add(1)
 	go r.runCallbacks()
 	conn.WriteBulk(value)
+}
+
+func (r *RoutingTable) rebalanceAckCommandHandler(conn redcon.Conn, cmd redcon.Command) {
+	// The command handlers of the routing table service should wait for the cluster join event.
+	<-r.joined
+
+	ackCmd, err := protocol.ParseRebalanceAckCommand(cmd)
+	if err != nil {
+		protocol.WriteError(conn, err)
+		return
+	}
+
+	if !r.discovery.IsCoordinator() {
+		protocol.WriteError(conn, fmt.Errorf("%w: rebalance coordinator mismatch", protocol.ErrInvalidArgument))
+		return
+	}
+
+	if !r.handleRebalanceAck(ackCmd.Epoch, ackCmd.MemberID) {
+		protocol.WriteError(conn, fmt.Errorf("%w: rebalance epoch is not active", protocol.ErrInvalidArgument))
+		return
+	}
+	conn.WriteString(protocol.StatusOK)
 }

--- a/internal/cluster/routingtable/rebalance.go
+++ b/internal/cluster/routingtable/rebalance.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Arsene Tochemey Gandote
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routingtable
+
+import (
+	"github.com/hashicorp/memberlist"
+
+	"github.com/tochemey/olric/internal/discovery"
+	"github.com/tochemey/olric/internal/protocol"
+)
+
+type rebalanceReason string
+
+const (
+	rebalanceReasonUnknown    rebalanceReason = "unknown"
+	rebalanceReasonPeriodic   rebalanceReason = "periodic"
+	rebalanceReasonManual     rebalanceReason = "manual"
+	rebalanceReasonNodeJoin   rebalanceReason = "node-join"
+	rebalanceReasonNodeLeft   rebalanceReason = "node-left"
+	rebalanceReasonNodeUpdate rebalanceReason = "node-update"
+)
+
+type rebalanceState struct {
+	epoch     uint64
+	pending   map[uint64]struct{}
+	acked     map[uint64]struct{}
+	completed bool
+}
+
+func rebalanceReasonFromEvent(event *discovery.ClusterEvent) (rebalanceReason, string) {
+	member, _ := discovery.NewMemberFromMetadata(event.NodeMeta)
+	switch event.Event {
+	case memberlist.NodeJoin:
+		return rebalanceReasonNodeJoin, member.String()
+	case memberlist.NodeLeave:
+		return rebalanceReasonNodeLeft, member.String()
+	case memberlist.NodeUpdate:
+		return rebalanceReasonNodeUpdate, member.String()
+	default:
+		return rebalanceReasonUnknown, ""
+	}
+}
+
+func (r *RoutingTable) startRebalanceEpoch(epoch uint64, reason rebalanceReason, node string) {
+	if epoch == 0 {
+		return
+	}
+
+	pending := make(map[uint64]struct{})
+	r.Members().RLock()
+	r.Members().Range(func(id uint64, _ discovery.Member) bool {
+		pending[id] = struct{}{}
+		return true
+	})
+	r.Members().RUnlock()
+	if len(pending) == 0 {
+		return
+	}
+
+	r.rebalanceMtx.Lock()
+	r.rebalanceState = rebalanceState{
+		epoch:   epoch,
+		pending: pending,
+		acked:   make(map[uint64]struct{}),
+	}
+	r.rebalanceMtx.Unlock()
+
+	if r.config.EnableClusterEventsChannel {
+		r.wg.Add(1)
+		go r.publishRebalanceStartEvent(epoch, string(reason), node)
+	}
+}
+
+func (r *RoutingTable) handleRebalanceAck(epoch, memberID uint64) bool {
+	r.rebalanceMtx.Lock()
+	defer r.rebalanceMtx.Unlock()
+
+	if r.rebalanceState.epoch == 0 || r.rebalanceState.epoch != epoch {
+		return false
+	}
+	if r.rebalanceState.completed {
+		return true
+	}
+	if _, ok := r.rebalanceState.pending[memberID]; !ok {
+		return true
+	}
+	if _, ok := r.rebalanceState.acked[memberID]; ok {
+		return true
+	}
+
+	r.rebalanceState.acked[memberID] = struct{}{}
+	if len(r.rebalanceState.acked) != len(r.rebalanceState.pending) {
+		return true
+	}
+
+	r.rebalanceState.completed = true
+	if r.config.EnableClusterEventsChannel {
+		r.wg.Add(1)
+		go r.publishRebalanceCompleteEvent(epoch)
+	}
+	return true
+}
+
+func (r *RoutingTable) SendRebalanceAck(epoch uint64) error {
+	if epoch == 0 {
+		return nil
+	}
+	coordinator := r.discovery.GetCoordinator()
+	if coordinator.ID == 0 {
+		return ErrNotJoinedYet
+	}
+	cmd := protocol.NewRebalanceAck(epoch, r.this.ID).Command(r.ctx)
+	rc := r.client.Get(coordinator.String())
+	err := rc.Process(r.ctx, cmd)
+	if err != nil {
+		return err
+	}
+	return cmd.Err()
+}

--- a/internal/cluster/routingtable/rebalance_test.go
+++ b/internal/cluster/routingtable/rebalance_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Arsene Tochemey Gandote
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routingtable
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/redcon"
+
+	"github.com/tochemey/olric/events"
+	"github.com/tochemey/olric/internal/discovery"
+	"github.com/tochemey/olric/internal/protocol"
+	"github.com/tochemey/olric/internal/testutil"
+)
+
+func TestRoutingTable_rebalanceCompleteEventOnAck(t *testing.T) {
+	cluster := newTestCluster()
+	defer cluster.cancel()
+
+	c := testutil.NewConfig()
+	c.EnableClusterEventsChannel = true
+	rt, err := cluster.addNode(c)
+	require.NoError(t, err)
+
+	peerCfg := testutil.NewConfig()
+	peerCfg.MemberlistConfig.Name = "127.0.0.1:9999"
+	peer := discovery.NewMember(peerCfg)
+
+	rt.Members().Lock()
+	rt.Members().Add(peer)
+	rt.Members().Unlock()
+
+	done := make(chan events.RebalanceCompleteEvent, 1)
+	rt.server.ServeMux().HandleFunc(protocol.PubSub.Publish, func(conn redcon.Conn, cmd redcon.Command) {
+		publishCmd, err := protocol.ParsePublishCommand(cmd)
+		require.NoError(t, err)
+		require.Equal(t, events.ClusterEventsChannel, publishCmd.Channel)
+
+		var envelope struct {
+			Kind string `json:"kind"`
+		}
+		err = json.Unmarshal([]byte(publishCmd.Message), &envelope)
+		require.NoError(t, err)
+		if envelope.Kind == events.KindRebalanceCompleteEvent {
+			var ev events.RebalanceCompleteEvent
+			err = json.Unmarshal([]byte(publishCmd.Message), &ev)
+			require.NoError(t, err)
+			done <- ev
+		}
+
+		conn.WriteInt(1)
+	})
+
+	rt.startRebalanceEpoch(42, rebalanceReasonNodeLeft, peer.String())
+	rt.handleRebalanceAck(42, rt.this.ID)
+
+	select {
+	case <-done:
+		t.Fatalf("rebalance completion should wait for all acks")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	rt.handleRebalanceAck(42, peer.ID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case ev := <-done:
+		require.Equal(t, events.KindRebalanceCompleteEvent, ev.Kind)
+		require.Equal(t, rt.this.String(), ev.Source)
+		require.Equal(t, uint64(42), ev.Epoch)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for rebalance completion event")
+	}
+}

--- a/internal/cluster/routingtable/routingtable.go
+++ b/internal/cluster/routingtable/routingtable.go
@@ -80,6 +80,9 @@ type RoutingTable struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	rebalanceMtx   sync.Mutex
+	rebalanceState rebalanceState
 }
 
 func registerErrors() {
@@ -233,10 +236,10 @@ func (r *RoutingTable) fillRoutingTable() {
 }
 
 func (r *RoutingTable) UpdateEagerly() {
-	r.updateRouting()
+	r.updateRoutingWithReason(rebalanceReasonManual, "")
 }
 
-func (r *RoutingTable) updateRouting() {
+func (r *RoutingTable) updateRoutingWithReason(reason rebalanceReason, node string) {
 	// This function is called by listenMemberlistEvents and updateRoutingPeriodically
 	// So this lock prevents parallel execution.
 	r.Lock()
@@ -255,12 +258,22 @@ func (r *RoutingTable) updateRouting() {
 	}
 
 	r.fillRoutingTable()
-	reports, err := r.updateRoutingTableOnCluster()
+	previousSignature := r.Signature()
+	data, signature, err := r.buildRoutingTablePayload()
+	if err != nil {
+		r.log.V(2).Printf("[ERROR] Failed to marshal routing table: %v", err)
+		return
+	}
+
+	reports, err := r.updateRoutingTableOnCluster(data)
 	if err != nil {
 		r.log.V(2).Printf("[ERROR] Failed to update routing table on cluster: %v", err)
 		return
 	}
 	r.processLeftOverDataReports(reports)
+	if signature != previousSignature {
+		r.startRebalanceEpoch(signature, reason, node)
+	}
 }
 
 func (r *RoutingTable) processClusterEvent(event *discovery.ClusterEvent) {
@@ -330,7 +343,8 @@ func (r *RoutingTable) listenClusterEvents(eventCh chan *discovery.ClusterEvent)
 			return
 		case e := <-eventCh:
 			r.processClusterEvent(e)
-			r.updateRouting()
+			reason, node := rebalanceReasonFromEvent(e)
+			r.updateRoutingWithReason(reason, node)
 		}
 	}
 }
@@ -345,7 +359,7 @@ func (r *RoutingTable) pushPeriodically() {
 		case <-r.ctx.Done():
 			return
 		case <-ticker.C:
-			r.updateRouting()
+			r.updateRoutingWithReason(rebalanceReasonPeriodic, "")
 		}
 	}
 }

--- a/internal/cluster/routingtable/update.go
+++ b/internal/cluster/routingtable/update.go
@@ -21,18 +21,26 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/tochemey/olric/internal/protocol"
-
+	"github.com/cespare/xxhash/v2"
 	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/tochemey/olric/internal/discovery"
+	"github.com/tochemey/olric/internal/protocol"
 )
 
 type leftOverDataReport struct {
 	Partitions []uint64
 	Backups    []uint64
+}
+
+func (r *RoutingTable) buildRoutingTablePayload() ([]byte, uint64, error) {
+	data, err := msgpack.Marshal(r.table)
+	if err != nil {
+		return nil, 0, err
+	}
+	return data, xxhash.Sum64(data), nil
 }
 
 func (r *RoutingTable) prepareLeftOverDataReport() ([]byte, error) {
@@ -73,12 +81,7 @@ func (r *RoutingTable) updateRoutingTableOnMember(data []byte, member discovery.
 	return &report, nil
 }
 
-func (r *RoutingTable) updateRoutingTableOnCluster() (map[discovery.Member]*leftOverDataReport, error) {
-	data, err := msgpack.Marshal(r.table)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *RoutingTable) updateRoutingTableOnCluster(data []byte) (map[discovery.Member]*leftOverDataReport, error) {
 	var mtx sync.Mutex
 	var g errgroup.Group
 	reports := make(map[discovery.Member]*leftOverDataReport)

--- a/internal/protocol/commands.go
+++ b/internal/protocol/commands.go
@@ -32,6 +32,7 @@ var Cluster = &ClusterCommands{
 type InternalCommands struct {
 	MoveFragment        string
 	UpdateRouting       string
+	RebalanceAck        string
 	LengthOfPart        string
 	ClusterRoutingTable string
 }
@@ -39,6 +40,7 @@ type InternalCommands struct {
 var Internal = &InternalCommands{
 	MoveFragment:  "internal.node.movefragment",
 	UpdateRouting: "internal.node.updaterouting",
+	RebalanceAck:  "internal.node.rebalanceack",
 	LengthOfPart:  "internal.node.lengthofpart",
 }
 

--- a/internal/protocol/system.go
+++ b/internal/protocol/system.go
@@ -119,6 +119,41 @@ func ParseUpdateRoutingCommand(cmd redcon.Command) (*UpdateRouting, error) {
 	return NewUpdateRouting(cmd.Args[1], coordinatorID), nil
 }
 
+type RebalanceAck struct {
+	Epoch    uint64
+	MemberID uint64
+}
+
+func NewRebalanceAck(epoch, memberID uint64) *RebalanceAck {
+	return &RebalanceAck{
+		Epoch:    epoch,
+		MemberID: memberID,
+	}
+}
+
+func (r *RebalanceAck) Command(ctx context.Context) *redis.StatusCmd {
+	var args []interface{}
+	args = append(args, Internal.RebalanceAck)
+	args = append(args, r.Epoch)
+	args = append(args, r.MemberID)
+	return redis.NewStatusCmd(ctx, args...)
+}
+
+func ParseRebalanceAckCommand(cmd redcon.Command) (*RebalanceAck, error) {
+	if len(cmd.Args) < 3 {
+		return nil, errWrongNumber(cmd.Args)
+	}
+	epoch, err := strconv.ParseUint(util.BytesToString(cmd.Args[1]), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	memberID, err := strconv.ParseUint(util.BytesToString(cmd.Args[2]), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return NewRebalanceAck(epoch, memberID), nil
+}
+
 type LengthOfPart struct {
 	PartID  uint64
 	Replica bool

--- a/internal/protocol/system_test.go
+++ b/internal/protocol/system_test.go
@@ -66,6 +66,17 @@ func TestProtocol_UpdateRoutingTable(t *testing.T) {
 	require.Equal(t, uint64(123), parsed.CoordinatorID)
 }
 
+func TestProtocol_RebalanceAck(t *testing.T) {
+	rebalanceAckCmd := NewRebalanceAck(42, 7)
+
+	cmd := stringToCommand(rebalanceAckCmd.Command(context.Background()).String())
+	parsed, err := ParseRebalanceAckCommand(cmd)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(42), parsed.Epoch)
+	require.Equal(t, uint64(7), parsed.MemberID)
+}
+
 func TestProtocol_LengthOfPart(t *testing.T) {
 	updateRoutingTableCmd := NewLengthOfPart(123)
 


### PR DESCRIPTION
- Emit rebalance-start-event and rebalance-complete-event tied to routing table epochs.
- Add internal rebalance ack command and coordinator tracking.
- Have balancer ack when no moves are pending for the current signature.
- Update docs and tests, plus improved test port allocation for UDP/TCP.