### PR TITLE
fix: DMap.Delete no longer drops keys owned by remote owners past the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.18 - 2026-07-24
+## [Unreleased]
 
 ### Fixed
 
-- `DMap.Delete(ctx, keys...)` no longer silently drops keys owned by remote partition owners past the first one. `deleteKeys` groups the requested keys by partition owner, then looped over that map to delete each group; the remote-owner branch returned unconditionally after handling the first remote owner (on both success and error), so any additional remote owners in the map were never processed and no error was returned. On a multi-node cluster, a multi-key delete spanning more than one remote owner beyond the first left the keys on every owner after that one untouched. The fan-out now uses `errgroup`, matching the pattern already used by `deleteBackupOnCluster`: every owner, local and remote, is processed, and the first error (if any) is returned only after all owners have been attempted; the returned count reflects the keys actually processed across every owner. Ported from the identical fix and reproduction test on [olric-data/olric#287](https://github.com/olric-data/olric/pull/287).
+- `DMap.Delete(ctx, keys...)` no longer silently drops keys owned by remote partition owners past the first one. `deleteKeys` groups the requested keys by partition owner, then looped over that map to delete each group; the remote-owner branch returned unconditionally after handling the first remote owner (on both success and error), so any additional remote owners in the map were never processed and no error was returned. On a multi-node cluster, a multi-key delete spanning more than one remote owner beyond the first left the keys on every owner after that one untouched. The fan-out now uses `errgroup`, matching the pattern already used by `deleteBackupOnCluster`: every owner, local and remote, is processed, and the first error (if any) is returned only after all owners have been attempted; the returned count reflects the keys actually processed across every owner.
 
 ## v0.3.15 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3.18 - 2026-07-24
+
+### Fixed
+
+- `DMap.Delete(ctx, keys...)` no longer silently drops keys owned by remote partition owners past the first one. `deleteKeys` groups the requested keys by partition owner, then looped over that map to delete each group; the remote-owner branch returned unconditionally after handling the first remote owner (on both success and error), so any additional remote owners in the map were never processed and no error was returned. On a multi-node cluster, a multi-key delete spanning more than one remote owner beyond the first left the keys on every owner after that one untouched. The fan-out now uses `errgroup`, matching the pattern already used by `deleteBackupOnCluster`: every owner, local and remote, is processed, and the first error (if any) is returned only after all owners have been attempted; the returned count reflects the keys actually processed across every owner. Ported from the identical fix and reproduction test on [olric-data/olric#287](https://github.com/olric-data/olric/pull/287).
+
 ## v0.3.15 - 2026-07-13
 
 ### Fixed

--- a/internal/dmap/delete.go
+++ b/internal/dmap/delete.go
@@ -20,6 +20,7 @@ package dmap
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 
@@ -151,26 +152,44 @@ func (dm *DMap) deleteKeys(ctx context.Context, keys ...string) (int, error) {
 		members[member] = append(members[member], key)
 	}
 
+	// Fan out to every owner instead of stopping at the first remote one -
+	// see the errgroup pattern used by deleteBackupOnCluster/deleteOnCluster.
+	var count int64
+	var g errgroup.Group
 	for member, distributedKeys := range members {
+		member, distributedKeys := member, distributedKeys
 		if member.CompareByName(dm.s.rt.This()) {
-			for _, key := range distributedKeys {
-				if err := dm.deleteKey(key); err != nil {
-					return 0, err
+			g.Go(func() error {
+				for _, key := range distributedKeys {
+					if err := dm.deleteKey(key); err != nil {
+						return err
+					}
 				}
-			}
-		} else {
+				atomic.AddInt64(&count, int64(len(distributedKeys)))
+				return nil
+			})
+			continue
+		}
+
+		g.Go(func() error {
 			cmd := protocol.NewDel(dm.name, distributedKeys...).Command(dm.s.ctx)
 			rc := dm.s.client.Get(member.String())
-			err := rc.Process(ctx, cmd)
-			if err != nil {
-				return 0, protocol.ConvertError(err)
+			if err := rc.Process(ctx, cmd); err != nil {
+				return protocol.ConvertError(err)
 			}
-
-			return 0, protocol.ConvertError(cmd.Err())
-		}
+			if err := cmd.Err(); err != nil {
+				return protocol.ConvertError(err)
+			}
+			atomic.AddInt64(&count, int64(len(distributedKeys)))
+			return nil
+		})
 	}
 
-	return len(keys), nil
+	if err := g.Wait(); err != nil {
+		return 0, err
+	}
+
+	return int(count), nil
 }
 
 // Delete deletes the value for the given key. Delete will not return error if key doesn't exist. It's thread-safe.

--- a/internal/dmap/delete.go
+++ b/internal/dmap/delete.go
@@ -152,12 +152,11 @@ func (dm *DMap) deleteKeys(ctx context.Context, keys ...string) (int, error) {
 		members[member] = append(members[member], key)
 	}
 
-	// Fan out to every owner instead of stopping at the first remote one -
-	// see the errgroup pattern used by deleteBackupOnCluster/deleteOnCluster.
+	// Fan out to every owner instead of stopping at the first remote one,
+	// following the errgroup pattern used by deleteBackupOnCluster.
 	var count int64
 	var g errgroup.Group
 	for member, distributedKeys := range members {
-		member, distributedKeys := member, distributedKeys
 		if member.CompareByName(dm.s.rt.This()) {
 			g.Go(func() error {
 				for _, key := range distributedKeys {

--- a/internal/dmap/delete_test.go
+++ b/internal/dmap/delete_test.go
@@ -101,6 +101,61 @@ func TestDMap_Delete_Cluster(t *testing.T) {
 	}
 }
 
+func TestDMap_Delete_MultiKeyDifferentRemoteOwners(t *testing.T) {
+	// Ported from the same fix on olric-data/olric (upstream PR
+	// https://github.com/olric-data/olric/pull/287): deleteKeys groups keys
+	// by partition owner and previously returned unconditionally after
+	// handling the first remote owner, silently skipping every remote owner
+	// after that. This reproduces the bug on a 3-node cluster by asserting
+	// the key set actually hashes to at least two different remote owners
+	// before calling Delete, so the multi-owner fan-out path is exercised.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	cluster.AddMember(nil)
+	cluster.AddMember(nil)
+	defer cluster.Shutdown()
+
+	dm1, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const keyCount = 30
+	for i := 0; i < keyCount; i++ {
+		err = dm1.Put(ctx, testutil.ToKey(i), testutil.ToVal(i), nil)
+		require.NoError(t, err)
+	}
+
+	// Sanity check: the keys must hash to at least two different owners other
+	// than s1 itself. Otherwise, deleteKeys' per-owner fan-out only has a
+	// single remote entry and this test wouldn't exercise the multi-owner
+	// code path where a bug could silently drop keys past the first remote
+	// owner.
+	remoteOwners := make(map[string]struct{})
+	for i := 0; i < keyCount; i++ {
+		hkey := partitions.HKey("mymap", testutil.ToKey(i))
+		owner := s1.primary.PartitionByHKey(hkey).Owner()
+		if !owner.CompareByName(s1.rt.This()) {
+			remoteOwners[owner.String()] = struct{}{}
+		}
+	}
+	require.GreaterOrEqual(t, len(remoteOwners), 2,
+		"test setup must distribute keys across at least two remote owners")
+
+	keys := make([]string, keyCount)
+	for i := 0; i < keyCount; i++ {
+		keys[i] = testutil.ToKey(i)
+	}
+
+	count, err := dm1.Delete(ctx, keys...)
+	require.NoError(t, err)
+	require.Equal(t, keyCount, count)
+
+	for i := 0; i < keyCount; i++ {
+		_, _, err = dm1.Get(ctx, testutil.ToKey(i))
+		require.ErrorIs(t, err, ErrKeyNotFound)
+	}
+}
+
 func TestDMap_Delete_Lookup(t *testing.T) {
 	cluster := testcluster.New(NewService)
 	s1 := cluster.AddMember(nil).(*Service)

--- a/internal/dmap/delete_test.go
+++ b/internal/dmap/delete_test.go
@@ -21,9 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tochemey/olric/config"
@@ -154,6 +157,153 @@ func TestDMap_Delete_MultiKeyDifferentRemoteOwners(t *testing.T) {
 		_, _, err = dm1.Get(ctx, testutil.ToKey(i))
 		require.ErrorIs(t, err, ErrKeyNotFound)
 	}
+}
+
+// newUnreachableMember returns a member whose address is a free local port with
+// nothing listening on it, so every attempt to dial it fails immediately with
+// connection refused. It is used to drive the remote failure branches of the
+// delete path without tearing a live member down.
+func newUnreachableMember(t *testing.T) discovery.Member {
+	t.Helper()
+
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
+
+	name := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	return discovery.Member{
+		Name:      name,
+		NameHash:  xxhash.Sum64([]byte(name)),
+		ID:        discovery.MemberID(name, 1),
+		Birthdate: 1,
+	}
+}
+
+func TestDMap_Delete_RemoteOwnerUnreachable(t *testing.T) {
+	// deleteKeys' remote branch has to surface a dial failure instead of
+	// swallowing it, and g.Wait's error has to reach the caller.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	dm, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := testutil.ToKey(1)
+	require.NoError(t, dm.Put(ctx, key, testutil.ToVal(1), nil))
+
+	// Hand the partition to a member that isn't listening, so the key is
+	// routed to a remote owner that cannot be dialed.
+	hkey := partitions.HKey("mymap", key)
+	s1.primary.PartitionByHKey(hkey).SetOwners([]discovery.Member{newUnreachableMember(t)})
+
+	count, err := dm.Delete(ctx, key)
+	require.Error(t, err)
+	require.Zero(t, count)
+}
+
+func TestDMap_Delete_PreviousOwnerUnreachable(t *testing.T) {
+	// The local owner branch delegates to deleteKey, which asks every previous
+	// owner to drop the key first. A previous owner that cannot be dialed must
+	// fail the whole delete rather than be skipped.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	dm, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := testutil.ToKey(1)
+	require.NoError(t, dm.Put(ctx, key, testutil.ToVal(1), nil))
+
+	// Owner() is the last entry, so this node stays the current owner while the
+	// unreachable member becomes a previous owner.
+	hkey := partitions.HKey("mymap", key)
+	s1.primary.PartitionByHKey(hkey).SetOwners([]discovery.Member{
+		newUnreachableMember(t),
+		s1.rt.This(),
+	})
+
+	count, err := dm.Delete(ctx, key)
+	require.Error(t, err)
+	require.Zero(t, count)
+}
+
+func TestDMap_Delete_BackupOwnerUnreachable(t *testing.T) {
+	// ReplicaCount is 1 by default, so deleteOnCluster fans the deletion out to
+	// the backup owners. A backup owner that cannot be dialed must fail the
+	// delete instead of leaving a stale replica behind silently.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	dm, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := testutil.ToKey(1)
+	require.NoError(t, dm.Put(ctx, key, testutil.ToVal(1), nil))
+
+	hkey := partitions.HKey("mymap", key)
+	s1.backup.PartitionByHKey(hkey).SetOwners([]discovery.Member{newUnreachableMember(t)})
+
+	count, err := dm.Delete(ctx, key)
+	require.Error(t, err)
+	require.Zero(t, count)
+}
+
+func TestDMap_Delete_PanicsWhenPartitionHasNoOwner(t *testing.T) {
+	// An empty owners list is a programming error: deleteOnCluster panics
+	// rather than deleting data whose replication targets are unknown.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	dm, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := testutil.ToKey(1)
+	require.NoError(t, dm.Put(ctx, key, testutil.ToVal(1), nil))
+
+	hkey := partitions.HKey("mymap", key)
+	s1.primary.PartitionByHKey(hkey).SetOwners([]discovery.Member{})
+
+	// Delete cannot be used here: grouping the keys by owner would panic in
+	// Partition.Owner before deleteOnCluster is ever reached.
+	require.Panics(t, func() {
+		_ = dm.deleteKey(key)
+	})
+}
+
+func TestDMap_Delete_MixedOwnersOneUnreachable(t *testing.T) {
+	// deleteKeys fans out to every owner. When one of them fails, the error has
+	// to win over the successful owners so the caller never reads a partial
+	// delete as a complete one.
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	dm, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const keyCount = 10
+	keys := make([]string, keyCount)
+	for i := 0; i < keyCount; i++ {
+		keys[i] = testutil.ToKey(i)
+		require.NoError(t, dm.Put(ctx, keys[i], testutil.ToVal(i), nil))
+	}
+
+	// Only the first key moves to an unreachable owner. The rest stay local, so
+	// the fan-out has both a healthy and a failing group.
+	hkey := partitions.HKey("mymap", keys[0])
+	s1.primary.PartitionByHKey(hkey).SetOwners([]discovery.Member{newUnreachableMember(t)})
+
+	count, err := dm.Delete(ctx, keys...)
+	require.Error(t, err)
+	require.Zero(t, count)
 }
 
 func TestDMap_Delete_Lookup(t *testing.T) {


### PR DESCRIPTION
## Summary

Port of a fix already proposed upstream for the same bug in `olric-data/olric`: https://github.com/olric-data/olric/pull/287

`deleteKeys` groups the requested keys by partition owner, then loops over that map to delete each group. The remote-owner branch of the loop returned unconditionally after handling the first remote owner (on both success and error), so any additional remote owners in the map were never processed. On a multi-node cluster, `Delete(ctx, keys...)` with enough keys to span more than one remote owner silently skipped deleting the keys owned by every remote owner after the first, and returned no error.

Verified the bug is present in this fork identically to `olric-data/olric`: same `deleteKeys` implementation, same unconditional `return` in the remote-owner `else` branch (`internal/dmap/delete.go`).

## Fix

Fan out with `errgroup`, matching the pattern already used by `deleteBackupOnCluster` in this same file: every owner (local and remote) is processed, and the first error (if any) is returned only after all owners have been attempted. The returned count now reflects the keys actually processed across all owners.

## Test plan

- [x] Ported `TestDMap_Delete_MultiKeyDifferentRemoteOwners`, which reproduces the bug deterministically on a 3-node cluster by asserting the test's own key set hashes to at least two different remote owners before calling `Delete`.
- [x] Confirmed the test fails on the unfixed `deleteKeys` (via `git stash` bisection) and passes 5/5 with the fix, including under `-race`.
- [x] `go test ./...` (all 37 packages) passes clean with the fix applied.